### PR TITLE
Add confirmation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,47 @@ App\Model\Order\Order:
                                             type: string
                                             description: 'The Klarna checkout confirmation snippet'
                                             example: '<div id="klarna-checkout-container"></div>'
+        shop_klarna_confirmation:
+            method: 'GET'
+            path: 'shop/orders/{tokenValue}/klarna-confirmation'
+            controller: NorthCreationAgency\SyliusKlarnaGatewayPlugin\Controller\KlarnaCheckoutController::confirmHeadless
+            openapi_context:
+                summary: Confirms current payment status of a Klarna order
+                responses:
+                    200:
+                        description: 'OK'
+                        content:
+                            application/json:
+                                schema:
+                                    type: object
+                                    properties:
+                                        message:
+                                            type: string
+                                            description: 'Updated payment status'
+                                            example: 'Updated payment state. New state: paid'
+                    400:
+                        description: 'BAD REQUEST'
+                        content:
+                            application/json:
+                                schema:
+                                    type: object
+                                    properties:
+                                        request_status:
+                                            type: integer
+                                            description: 'Klarna server status'
+                                        error_message:
+                                            type: string
+                                            description: 'Error details'
+                    500:
+                        description: 'INTERNAL SERVER ERROR'
+                        content:
+                            application/json:
+                                schema:
+                                    type: object
+                                    properties:
+                                        error_message:
+                                            type: string
+                                            description: 'Error details'
 ```
 
 In _plugin development_ environment, the api-config is imported by adding the following to 

--- a/config/klarna_routes.yaml
+++ b/config/klarna_routes.yaml
@@ -2,7 +2,7 @@ north_creation_agency_sylius_klarna_gateway_confirm:
     path: /klarna-checkout/confirm
     methods: [GET]
     defaults:
-        _controller: NorthCreationAgency\SyliusKlarnaGatewayPlugin\Controller\KlarnaCheckoutController::confirm
+        _controller: NorthCreationAgency\SyliusKlarnaGatewayPlugin\Controller\KlarnaCheckoutController::confirmWithRedirect
 
 north_creation_agency_sylius_klarna_gateway_push:
     path: /klarna-checkout/push

--- a/config/packages/nca_klarna.yaml
+++ b/config/packages/nca_klarna.yaml
@@ -2,6 +2,7 @@ north_creation_agency_sylius_klarna_gateway:
     cypher:
         key: '%env(PAYUM_CYPHER_KEY)%'
     checkout:
+        headless: true
         push_confirmation: https://api.playground.klarna.com/ordermanagement/v1/orders/{order_id}/acknowledge
         read_order: https://api.playground.klarna.com/ordermanagement/v1/orders/{order_id}
         uri: https://api.playground.klarna.com/checkout/v3/orders

--- a/src/Api/Data/StatusDO.php
+++ b/src/Api/Data/StatusDO.php
@@ -9,31 +9,22 @@ class StatusDO
     public function __construct(
         private int $status,
         private ?string $message,
-        private ?string $errorMessage
-    ){}
+        private ?string $errorMessage,
+    ) {
+    }
 
-    /**
-     * @return int
-     */
     public function getStatus(): int
     {
         return $this->status;
     }
 
-    /**
-     * @return string|null
-     */
     public function getMessage(): ?string
     {
         return $this->message;
     }
 
-    /**
-     * @return string|null
-     */
     public function getErrorMessage(): ?string
     {
         return $this->errorMessage;
     }
-
 }

--- a/src/Api/Data/StatusDO.php
+++ b/src/Api/Data/StatusDO.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NorthCreationAgency\SyliusKlarnaGatewayPlugin\Api\Data;
+
+class StatusDO
+{
+    public function __construct(
+        private int $status,
+        private ?string $message,
+        private ?string $errorMessage
+    ){}
+
+    /**
+     * @return int
+     */
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getErrorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+
+}

--- a/src/Controller/KlarnaCheckoutController.php
+++ b/src/Controller/KlarnaCheckoutController.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Exception\RequestException;
 use NorthCreationAgency\SyliusKlarnaGatewayPlugin\Api\Authentication\BasicAuthenticationRetrieverInterface;
 use NorthCreationAgency\SyliusKlarnaGatewayPlugin\Api\Checkout\KlarnaRequestStructure;
 use NorthCreationAgency\SyliusKlarnaGatewayPlugin\Api\Checkout\MerchantData;
+use NorthCreationAgency\SyliusKlarnaGatewayPlugin\Api\Data\StatusDO;
 use NorthCreationAgency\SyliusKlarnaGatewayPlugin\Api\DataUpdater;
 use NorthCreationAgency\SyliusKlarnaGatewayPlugin\Api\Exception\ApiException;
 use NorthCreationAgency\SyliusKlarnaGatewayPlugin\Router\UrlGenerator;
@@ -180,6 +181,11 @@ class KlarnaCheckoutController extends AbstractController
 
     public function getConfirmationSnippet(string $tokenValue): Response
     {
+        /** @var ?OrderInterface $order */
+        $order = $this->orderRepository->findOneBy(['tokenValue' => $tokenValue]);
+        assert($order instanceof OrderInterface);
+        $this->confirm($order);
+
         $payment = $this->getPaymentFromOrderToken($tokenValue);
 
         assert($payment instanceof PaymentInterface);
@@ -251,12 +257,11 @@ class KlarnaCheckoutController extends AbstractController
         );
     }
 
-    public function confirm(Request $request): Response
+    public function confirm(OrderInterface $order): StatusDO
     {
-        $orderToken = $request->query->get('order_token') ?? '';
-        $order = $this->orderRepository->findOneBy(['tokenValue' => $orderToken]);
+        $errorMessage = null;
+        $message = null;
 
-        assert($order instanceof OrderInterface);
         $klarnaData = $this->fetchOrderDataFromKlarna($order);
 
         try {
@@ -297,18 +302,62 @@ class KlarnaCheckoutController extends AbstractController
             );
 
             $status = $response->getStatusCode();
+        } catch (GuzzleException $e) {
+            $status = $e->getCode();
+            $errorMessage = 'Could not retrieve data from Klarna.';
         } catch (\Exception $e) {
-            $status = 400;
+            $status = 500;
+            $errorMessage = 'Server error.';
         }
 
-        if ($status === 204) {
-            $paymentState = $payment->getState();
-            if ($paymentState !== PaymentInterfaceAlias::STATE_COMPLETED) {
+        if ($status === Response::HTTP_NO_CONTENT) {
+            if ($payment->getState() !== PaymentInterfaceAlias::STATE_COMPLETED) {
                 $this->updateState($order);
+                $message = 'Updated payment state. New state: ' . $order->getPaymentState();
             }
+        } else {
+            $message = 'Payment state was not updated. Current state: ' . $order->getPaymentState();
         }
 
         $this->entityManager->flush();
+
+        return new StatusDO($status, $message, $errorMessage);
+    }
+
+    public function confirmHeadless(Request $request): Response
+    {
+        $orderToken = $request->attributes->get('tokenValue') ?? '';
+        $order = $this->orderRepository->findOneBy(['tokenValue' => $orderToken]);
+        assert($order instanceof OrderInterface);
+
+        $statusDO = $this->confirm($order);
+        $status = $statusDO->getStatus();
+        return match($status){
+            Response::HTTP_NO_CONTENT => new JsonResponse([
+                'message' => $statusDO->getMessage()],
+                Response::HTTP_OK
+            ),
+            Response::HTTP_INTERNAL_SERVER_ERROR => new JsonResponse([
+                'error_message' => $statusDO->getErrorMessage()],
+                $status
+            ),
+            default => new JsonResponse([
+                'request_status' => $status,
+                'error_message' => $statusDO->getErrorMessage()],
+                Response::HTTP_BAD_REQUEST
+            )
+        };
+
+    }
+
+    public function confirmWithRedirect(Request $request): Response
+    {
+        $orderToken = $request->query->get('order_token') ?? '';
+        $order = $this->orderRepository->findOneBy(['tokenValue' => $orderToken]);
+        assert($order instanceof OrderInterface);
+
+        $method = $order->getLastPayment()?->getMethod();
+        assert($method instanceof PaymentMethodInterface);
 
         $redirectUrl = $this->getConfirmationUrl($method, ['tokenValue' => $orderToken]);
 
@@ -451,12 +500,18 @@ class KlarnaCheckoutController extends AbstractController
         /** @var string|null $checkoutUrl */
         $checkoutUrl = $merchantData['checkoutUrl'] ?? null;
 
-        /** @var string|null $confirmationUrl */
-        $confirmationUrl = $this->generateUrl(
+        /** @var boolean $headlessMode */
+        $headlessMode = $this->parameterBag->get('north_creation_agency_sylius_klarna_gateway.checkout.read_order') ?? false;
+
+        /** @var string|null $confirmationHeadlessUrl */
+        $confirmationHeadfullUrl = $this->generateUrl(
             'north_creation_agency_sylius_klarna_gateway_confirm',
             ['order_token' => $payment->getOrder()?->getTokenValue() ?? ''],
             UrlGeneratorInterface::ABSOLUTE_URL,
         );
+
+        /** @var string|null $confirmationUrl */
+        $confirmationUrl = $headlessMode ? $merchantData['confirmationUrl'] : $confirmationHeadfullUrl;
 
         if (null === $termsUrl || null === $checkoutUrl || null === $confirmationUrl || null === $pushUrl) {
             return null;
@@ -468,6 +523,7 @@ class KlarnaCheckoutController extends AbstractController
             $urlGenerator = new UrlGenerator($router);
             $termsUrl = $urlGenerator->generateAbsoluteURL($termsUrl);
             $checkoutUrl = $urlGenerator->generateAbsoluteURL($checkoutUrl);
+            $confirmationUrl = $urlGenerator->generateAbsoluteURL($confirmationUrl, ['tokenValue' => $order->getTokenValue() ?? '']);
         } catch (\Exception $e) {
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('checkout')
                     ->children()
+                        ->booleanNode('headless')->end()
                         ->scalarNode('read_order')->end()
                         ->scalarNode('push_confirmation')->end()
                         ->scalarNode('uri')->end()

--- a/src/DependencyInjection/NorthCreationAgencySyliusKlarnaGatewayExtension.php
+++ b/src/DependencyInjection/NorthCreationAgencySyliusKlarnaGatewayExtension.php
@@ -38,6 +38,15 @@ final class NorthCreationAgencySyliusKlarnaGatewayExtension extends Extension
         }
 
         if (array_key_exists('checkout', $config)) {
+            if (is_array($config['checkout']) && array_key_exists('headless', $config['checkout'])) {
+                /** @var string|null $headless */
+                $headless = $config['checkout']['headless'] ?? '';
+                $container->setParameter(
+                    'north_creation_agency_sylius_klarna_gateway.checkout.headless',
+                    $headless,
+                );
+            }
+
             if (is_array($config['checkout']) && array_key_exists('read_order', $config['checkout'])) {
                 /** @var string|null $readOrder */
                 $readOrder = $config['checkout']['read_order'] ?? '';

--- a/tests/Application/config/api_platform/Order.yaml
+++ b/tests/Application/config/api_platform/Order.yaml
@@ -36,3 +36,44 @@ Sylius\Component\Core\Model\Order:
                                             type: string
                                             description: 'The Klarna checkout confirmation snippet'
                                             example: '<div id="klarna-checkout-container"></div>'
+        shop_klarna_confirmation:
+            method: 'GET'
+            path: 'shop/orders/{tokenValue}/klarna-confirmation'
+            controller: NorthCreationAgency\SyliusKlarnaGatewayPlugin\Controller\KlarnaCheckoutController::confirmHeadless
+            openapi_context:
+                summary: Confirms current payment status of a Klarna order
+                responses:
+                    200:
+                        description: 'OK'
+                        content:
+                            application/json:
+                                schema:
+                                    type: object
+                                    properties:
+                                        message:
+                                            type: string
+                                            description: 'Updated payment status'
+                                            example: 'Updated payment state. New state: paid'
+                    400:
+                        description: 'BAD REQUEST'
+                        content:
+                            application/json:
+                                schema:
+                                    type: object
+                                    properties:
+                                        request_status:
+                                            type: integer
+                                            description: 'Klarna server status'
+                                        error_message:
+                                            type: string
+                                            description: 'Error details'
+                    500:
+                        description: 'INTERNAL SERVER ERROR'
+                        content:
+                            application/json:
+                                schema:
+                                    type: object
+                                    properties:
+                                        error_message:
+                                            type: string
+                                            description: 'Error details'

--- a/tests/Application/config/packages/nca_klarna.yaml
+++ b/tests/Application/config/packages/nca_klarna.yaml
@@ -2,6 +2,7 @@ north_creation_agency_sylius_klarna_gateway:
     cypher:
         key: '%env(PAYUM_CYPHER_KEY)%'
     checkout:
+        headless: true
         push_confirmation: https://api.playground.klarna.com/ordermanagement/v1/orders/{order_id}/acknowledge
         read_order: https://api.playground.klarna.com/ordermanagement/v1/orders/{order_id}
         uri: https://api.playground.klarna.com/checkout/v3/orders


### PR DESCRIPTION
Closes #33 - add confirmation endpoint

Controller method is added to hook an API endpoint to.

Adds new configuration option: `north_creation_agency_sylius_klarna_gateway.checkout.headless` _(boolean)_

Add this configuration for Order.yaml (notice that you may use `App\Model\Order\Order` instead of the example here):
```yaml
Sylius\Component\Core\Model\Order:
    itemOperations:
        shop_klarna_confirmation:
            method: 'GET'
            path: 'shop/orders/{tokenValue}/klarna-confirmation'
            controller: NorthCreationAgency\SyliusKlarnaGatewayPlugin\Controller\KlarnaCheckoutController::confirmHeadless
            openapi_context:
                summary: Confirms current payment status of a Klarna order
                responses:
                    200:
                        description: 'OK'
                        content:
                            application/json:
                                schema:
                                    type: object
                                    properties:
                                        message:
                                            type: string
                                            description: 'Updated payment status'
                                            example: 'Updated payment state. New state: paid'
                    400:
                        description: 'BAD REQUEST'
                        content:
                            application/json:
                                schema:
                                    type: object
                                    properties:
                                        request_status:
                                            type: integer
                                            description: 'Klarna server status'
                                        error_message:
                                            type: string
                                            description: 'Error details'
                    500:
                        description: 'INTERNAL SERVER ERROR'
                        content:
                            application/json:
                                schema:
                                    type: object
                                    properties:
                                        error_message:
                                            type: string
                                            description: 'Error details'
```

